### PR TITLE
Fix GitHub repo URL change

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -35,7 +35,7 @@
 		{
 			"name": "GitHub",
 			"icon": "github",
-			"url": "https://github.com/unbound-mod"
+			"url": "https://github.com/unbound-app"
 		}
 	],
 	"feedback": {
@@ -121,7 +121,7 @@
 	],
 	"footerSocials": {
 		"x": "https://twitter.com/UnboundClient",
-		"github": "https://github.com/unbound-mod",
+		"github": "https://github.com/unbound-app",
 		"discord": "https://discord.gg/unbound"
 	}
 }


### PR DESCRIPTION
Fix GitHub repo url change from https://github.com/unbound-mod to https://github.com/unbound-app